### PR TITLE
real time RSS feed processing updates with SSE

### DIFF
--- a/src/components/rss_test.rs
+++ b/src/components/rss_test.rs
@@ -1,136 +1,113 @@
 use leptos::*;
-use leptos_router::ActionForm;
-use crate::server_fn::{TriggerRssFetchStream, RssProgressUpdate};
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::JsCast;
+use web_sys::{EventSource, MessageEvent, ErrorEvent};
 use std::collections::HashMap;
+use crate::server_fn::RssProgressUpdate;
 
 #[component]
 pub fn RssTest() -> impl IntoView {
-    let trigger_action = create_server_action::<TriggerRssFetchStream>();
-    
-    let (company_states, set_company_states) = create_signal::<HashMap<String, RssProgressUpdate>>(HashMap::new());
-    
-    let completed_companies = create_memo(move |_| {
-        company_states.get()
-            .iter()
-            .filter(|(_, status)| status.status == "completed")
-            .map(|(company, _)| company.to_string())
-            .collect::<Vec<_>>()
-    });
+    let (progress_states, set_progress_states) = create_signal::<HashMap<String, RssProgressUpdate>>(HashMap::new());
 
-    create_effect(move |_| {
-        if let Some(Ok(updates)) = trigger_action.value().get() {
-            let mut new_states = HashMap::new();
-            for update in updates {
-                new_states.insert(update.company.clone(), update);
+    let start_streaming = move || {
+        let event_source = EventSource::new("/api/rss-progress")
+            .expect("Failed to connect to SSE endpoint");
+            
+        let event_source_clone = event_source.clone();
+
+        let on_message = Closure::wrap(Box::new(move |event: MessageEvent| {
+            if let Some(data) = event.data().as_string() {
+                if data == "[DONE]" { event_source_clone.close();
+                } else {
+                    match serde_json::from_str::<RssProgressUpdate>(&data) {
+                        Ok(update) => {
+                            set_progress_states.update(|states| {
+                                states.insert(update.company.clone(), update);
+                            });
+                        },
+                        Err(e) => log::error!("Failed to parse update: {}", e)
+                    }
+                }
             }
-            set_company_states.set(new_states);
-        }
-    });
+        }) as Box<dyn FnMut(_)>);
 
-    let get_card_classes = move |update: &RssProgressUpdate| {
-        let base_classes = "transition-all transform bg-gray-200 dark:bg-teal-900 p-3 rounded-lg";
-        let status_classes = match update.status.as_str() {
-            "completed" => "border-l-4 border-seafoam-500 dark:border-mint-800 translate-x-1",
-            "processing" => "border-l-4 border-aqua-500 dark:border-seafoam-400",
-            _ => "border-l-4 border-gray-400 dark:border-gray-800 opacity-50"
-        };
-        format!("{} {}", base_classes, status_classes)
-    };
+        let event_source_error = event_source.clone();
+        let on_error = Closure::wrap(Box::new(move |error: ErrorEvent| {
+            log::error!("SSE Error: {:?}", error);
+            event_source_error.close();
+        }) as Box<dyn FnMut(_)>);
 
-    let get_status_badge_classes = move |status: &str| {
-        let base_classes = "text-sm px-2 py-1 rounded";
-        let status_classes = if status == "completed" {
-            "bg-seafoam-200 dark:bg-mint-900/30 text-seafoam-900 dark:text-mint-700"
-        } else {
-            "bg-aqua-200 dark:bg-seafoam-900/30 text-aqua-900 dark:text-seafoam-300"
-        };
-        format!("{} {}", base_classes, status_classes)
+        event_source.set_onmessage(Some(on_message.as_ref().unchecked_ref()));
+        event_source.set_onerror(Some(on_error.as_ref().unchecked_ref()));
+        
+        // Keep the closures alive
+        on_message.forget();
+        on_error.forget();
     };
 
     view! {
         <div class="p-4 space-y-4">
-            <ActionForm action=trigger_action>
-                <button
-                    type="submit"
-                    class="px-4 py-2 bg-seafoam-500 dark:bg-aqua-600 text-white dark:text-teal-100 rounded 
-                           hover:bg-seafoam-400 dark:hover:bg-aqua-500 
-                           disabled:bg-gray-300 dark:disabled:bg-gray-800 
-                           disabled:text-gray-500 dark:disabled:text-gray-600 
-                           transition-colors"
-                    disabled=move || trigger_action.pending().get()
-                >
-                    {move || if trigger_action.pending().get() {
-                        view! {
-                            <>
-                            <span class="inline-flex items-center">
-                                <span class="animate-spin mr-2">"↻"</span>
-                                "Processing Feeds..."
-                            </span>
-                            </>
-                        }
-                    } else {
-                        view! { <>"Trigger RSS Fetch"</> }
-                    }}
-                </button>
-            </ActionForm>
+            <button
+                class="px-4 py-2 bg-seafoam-500 dark:bg-aqua-600 text-white dark:text-teal-100 rounded 
+                       hover:bg-seafoam-400 dark:hover:bg-aqua-500 transition-colors"
+                on:click=move |_| start_streaming()
+            >
+                "Start RSS Fetch"
+            </button>
 
             {move || {
-                let states = company_states.get();
+                let states = progress_states.get();
                 if states.is_empty() {
                     view! {
-                        <div class="mt-4 p-4 text-center animate-pulse text-gray-500 dark:text-gray-600">
+                        <div class="mt-4 p-4 text-center text-gray-500 dark:text-gray-600">
                             "Waiting to start processing..."
                         </div>
                     }
                 } else {
                     view! {
-                        <div class="mt-4 space-y-2">
-                            <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-400 mb-4">
-                                "Feed Processing Results "
-                                <span class="text-sm text-gray-500 dark:text-gray-600">
-                                    {format!("({} completed)", completed_companies.get().len())}
-                                </span>
-                            </h3>
-                            <div class="grid gap-3">
-                                {states.values().map(|update| {
-                                    let status = update.status.clone();
-                                    let company = update.company.clone();
-                                    let new_posts = update.new_posts;
-                                    let skipped_posts = update.skipped_posts;
-                                    let current_post = update.current_post.clone();
-                                    
-                                    view! {
-                                        <div class={get_card_classes(update)}>
-                                            <div class="flex justify-between items-center">
-                                                <span class="text-seafoam-800 dark:text-mint-600 font-medium">
-                                                    {company}
-                                                </span>
-                                                <span class={get_status_badge_classes(&status)}>
-                                                    {status}
-                                                </span>
-                                            </div>
-                                            <div class="mt-2 text-gray-700 dark:text-gray-500 text-sm grid gap-1">
-                                                <div class="flex justify-between">
-                                                    <span>"New posts"</span>
-                                                    <span class="text-aqua-600 dark:text-aqua-300">{new_posts}</span>
-                                                </div>
-                                                <div class="flex justify-between">
-                                                    <span>"Skipped posts"</span>
-                                                    <span class="text-gray-500 dark:text-gray-600">{skipped_posts}</span>
-                                                </div>
-                                                {current_post.map(|post| view! {
-                                                    <div class="mt-1 text-sm">
-                                                        <span class="text-gray-500 dark:text-gray-600">"Processing: "</span>
-                                                        <span class="text-seafoam-600 dark:text-seafoam-300 truncate block">
-                                                            {post}
-                                                        </span>
-                                                    </div>
-                                                })}
-                                            </div>
+                        <div class="mt-4 grid gap-3">
+                            {states.values().map(|update| {
+                                let class = match update.status.as_str() {
+                                    "completed" => "bg-gray-200 dark:bg-teal-900 p-3 rounded-lg border-l-4 border-seafoam-500 dark:border-mint-800 translate-x-1",
+                                    "processing" => "bg-gray-200 dark:bg-teal-900 p-3 rounded-lg border-l-4 border-aqua-500 dark:border-seafoam-400",
+                                    _ => "bg-gray-200 dark:bg-teal-900 p-3 rounded-lg border-l-4 border-gray-400 dark:border-gray-800 opacity-50"
+                                };
+                                let status_class = if update.status == "completed" {
+                                    "text-sm px-2 py-1 rounded bg-seafoam-200 dark:bg-mint-900/30 text-seafoam-900 dark:text-mint-700"
+                                } else {
+                                    "text-sm px-2 py-1 rounded bg-aqua-200 dark:bg-seafoam-900/30 text-aqua-900 dark:text-seafoam-300"
+                                };
+                                view! {
+                                    <div class={class}>
+                                        <div class="flex justify-between items-center">
+                                            <span class="text-seafoam-800 dark:text-mint-600 font-medium">
+                                                {update.company.clone()}
+                                            </span>
+                                            <span class={status_class}>
+                                                {update.status.clone()}
+                                            </span>
                                         </div>
-                                    }
-                                }).collect_view()}
-                            </div>
+                                        <div class="mt-2 text-sm grid gap-1">
+                                            <div class="flex justify-between">
+                                                <span>"New posts"</span>
+                                                <span>{update.new_posts}</span>
+                                            </div>
+                                            <div class="flex justify-between">
+                                                <span>"Skipped posts"</span>
+                                                <span>{update.skipped_posts}</span>
+                                            </div>
+                                            {update.current_post.as_ref().map(|post| view! {
+                                                <div class="mt-1">
+                                                    <span class="text-gray-500">"Processing: "</span>
+                                                    <span class="text-seafoam-600 dark:text-seafoam-300 truncate">
+                                                        {post}
+                                                    </span>
+                                                </div>
+                                            })}
+                                        </div>
+                                    </div>
+                                }
+                            }).collect_view()}
                         </div>
                     }
                 }

--- a/src/rss_service.rs
+++ b/src/rss_service.rs
@@ -189,7 +189,7 @@ pub mod server {
                 user_message.into(),
             ],
             response_format: Some(ResponseFormat::JsonObject),
-            max_tokens: Some(100),
+            max_tokens: Some(200),
             ..Default::default()
         };
 


### PR DESCRIPTION

# Add real time RSS feed processing updates

this PR adds server-sent events (SSE) to provide real-time feedback (on the
client) during RSS feed processing. admins can now see the progress in
real-time, no need to view server logs to view progress

## Changes

- added `/api/rss-progress` SSE endpoint that streams feed processing status
- implemented channel bridging between futures and tokio to handle async streams
- updated RssTest component with real-time progress viz

## Implementation details

The server uses a combination of futures and tokio channels to bridge between
the RSS processing logic and SSE stream. The client component maintains a
reactive HashMap of company statuses, but now the UI updates in real-time as
updates arrive.

## Testing

- manually tested SSE connection
- vefified proper error handling and (not) connection cleanup
- confirmed UI updates match the processing state

## Known Issues
- [ ] EventSource connections currently don't receive a [DONE] message and may stay open. Need to implement proper connection cleanup either by: 
1. Adding [DONE] message after RSS processing completes
2. Implementing alternative cleanup strat
3. Adding connection timeout as a failsafe (ew)

